### PR TITLE
feat: allow using env vars in config source

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -62,11 +63,11 @@ func readConfig(configBytes []byte, keyRegex *regexp.Regexp) ([]string, []types.
 				awsConfigType = types.DefaultCfgType
 			case strings.HasPrefix(env.AwsConfigSource, "profile:::"):
 				configElements := strings.Split(env.AwsConfigSource, "profile:::")
-				awsConfigSource = configElements[len(configElements)-1]
+				awsConfigSource = os.ExpandEnv(configElements[len(configElements)-1])
 				awsConfigType = types.SharedCfgProfileType
 			case strings.HasPrefix(env.AwsConfigSource, "assume-role:::"):
 				configElements := strings.Split(env.AwsConfigSource, "assume-role:::")
-				awsConfigSource = configElements[len(configElements)-1]
+				awsConfigSource = os.ExpandEnv(configElements[len(configElements)-1])
 				awsConfigType = types.AssumeRoleCfgType
 			default:
 				return nil,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ Usage: ecsv [flags]`
 var (
 	configFileName   = "ecsv/ecsv.yml"
 	keyFilter        = flag.String("key", "", "regex for filtering systems (by key)")
-	format           = flag.String("f", "default", "output format to use [possible values: default, html]")
+	format           = flag.String("f", "default", fmt.Sprintf("output format to use [possible values: %s]", strings.Join(types.OutputFormats(), ", ")))
 	htmlTemplateFile = flag.String("t", "", "path of the HTML template file to use")
 	htmlTitle        = flag.String("html-title", "ecsv", "title to be used in the html output")
 	style            = flag.String("style", types.ASCIIStyle.String(), fmt.Sprintf("style to use [possible values: %s]", strings.Join(types.TableStyleStrings(), ", ")))

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -13,6 +13,10 @@ const (
 	HTMLFmt
 )
 
+func OutputFormats() []string {
+	return []string{"default", "table", "html"}
+}
+
 type AWSConfigSourceType uint
 
 const (


### PR DESCRIPTION
This might become useful for providing a config source as:

aws-config-source: assume-role:::arn:aws:iam::$ACCOUNT_ID:role/some-role
