### PR TITLE
upgrade toolchain to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhth/ecsv
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -175,7 +175,7 @@ func getTerminalOutput(config Config, results map[string]map[string]types.Versio
 	s.WriteString(systemStyle.Render("system"))
 
 	for _, env := range config.EnvSequence {
-		s.WriteString(fmt.Sprintf("%s    ", envSt.Render(env)))
+		fmt.Fprintf(&s, "%s    ", envSt.Render(env))
 	}
 	s.WriteString("\n\n")
 	errorIndex := 0


### PR DESCRIPTION
## Summary
- upgrade the Go toolchain from 1.26.1 to 1.26.2
- replace WriteString(fmt.Sprintf(...)) with fmt.Fprintf to satisfy staticcheck on the newer toolchain/lint path